### PR TITLE
Остутствуют заменил на Отсутствуют

### DIFF
--- a/android.yaml
+++ b/android.yaml
@@ -2007,7 +2007,7 @@ Sections:
       cs: Žádné
       ka: არ იძებნება
       kk: Жоқ
-      ru: Остутствуют
+      ru: Отсутствуют
       uk: Відсутні
     date_time_placeholder:
       en: --.--.---- --:--:--


### PR DESCRIPTION
 none:
      en: None
      cs: Žádné
      ka: არ იძებნება
      kk: Жоқ
      ru: Отсутствуют  (Исправил грамматическую ошибку)
      uk: Відсутні